### PR TITLE
Running in simulator

### DIFF
--- a/src/BlackSP.Benchmarks/BlackSP.Benchmarks.csproj
+++ b/src/BlackSP.Benchmarks/BlackSP.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>f4915771-4326-4cd3-8ae6-faea10088de0</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +26,8 @@
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.7.0" />
     <PackageReference Include="Lorem.NET" Version="1.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.13" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="6.1.1" />
   </ItemGroup>
   

--- a/src/BlackSP.Benchmarks/Extensions.cs
+++ b/src/BlackSP.Benchmarks/Extensions.cs
@@ -19,6 +19,8 @@ namespace BlackSP.Benchmarks
         {
             switch(benchmark)
             {
+                case Job.WordCountInternal:
+                    return WordCount.Queries.WordCountInternal(size);
                 case Job.WordCount:
                     return WordCount.Queries.WordCount(size);
                 case Job.Projection:

--- a/src/BlackSP.Benchmarks/Program.cs
+++ b/src/BlackSP.Benchmarks/Program.cs
@@ -8,6 +8,7 @@ using BlackSP.Infrastructure;
 using BlackSP.Infrastructure.Models;
 using BlackSP.Kernel.Configuration;
 using CRA.ClientLibrary;
+using Microsoft.Extensions.Configuration;
 using Serilog.Events;
 using System;
 using System.Collections.Generic;
@@ -23,7 +24,7 @@ namespace BlackSP.Benchmarks
         {
             CultureInfo.CurrentCulture = CultureInfo.CreateSpecificCulture("nl-NL");
             CultureInfo.CurrentUICulture = CultureInfo.CreateSpecificCulture("nl-NL");
-
+            LoadUserSecretsIntoEnvironment();
 #if TRACE && false
             Environment.SetEnvironmentVariable("AZURE_STORAGE_CONN_STRING", "DefaultEndpointsProtocol=https;AccountName=vertexstore;AccountKey=3BMGVlrXZq8+NE9caC47KDcpZ8X59vvxFw21NLNNLFhKGgmA8Iq+nr7naEd7YuGGz+M0Xm7dSUhgkUN5N9aMLw==;EndpointSuffix=core.windows.net");
             Environment.SetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING", "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;");
@@ -187,6 +188,25 @@ namespace BlackSP.Benchmarks
                 .Build();
 
             await app.RunAsync();
+        }
+
+        /// <summary>
+        /// Retrieves values from visual studio user secrets and loads them into the current process's environment variables.
+        /// </summary>
+        static void LoadUserSecretsIntoEnvironment()
+        {
+            var config = new ConfigurationBuilder().AddUserSecrets<Program>().Build();
+            var connstr = config.GetValue<string>("AZURE_STORAGE_CONN_STRING");
+            if(!string.IsNullOrEmpty(connstr))
+            {
+                Environment.SetEnvironmentVariable("AZURE_STORAGE_CONN_STRING", connstr);
+            }
+
+            connstr = config.GetValue<string>("AZURE_STORAGE_CONNECTION_STRING");
+            if (!string.IsNullOrEmpty(connstr))
+            {
+                Environment.SetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING", connstr);
+            }
         }
     }
 }

--- a/src/BlackSP.Benchmarks/ProgramArgs.cs
+++ b/src/BlackSP.Benchmarks/ProgramArgs.cs
@@ -12,6 +12,7 @@ namespace BlackSP.Benchmarks
 
     public enum Job
     {
+        WordCountInternal = -1,
         WordCount,
         Projection,
         Selection,

--- a/src/BlackSP.Benchmarks/Properties/launchSettings.json
+++ b/src/BlackSP.Benchmarks/Properties/launchSettings.json
@@ -94,7 +94,7 @@
         "LOG_TARGET_FLAGS": "3", // 1 (console) || 2 (file) || 4 (azure blob)
         "LOG_EVENT_LEVEL": "2", //0-5,
 
-        "CHECKPOINT_COORDINATION_MODE": "2", //0 = uc, 1 = cc, 2 = cic
+        "CHECKPOINT_COORDINATION_MODE": "1", //0 = uc, 1 = cc, 2 = cic
         "CHECKPOINT_INTERVAL_SECONDS": "15",
 
         "BENCHMARK_INFRA": "0", //0 = simulator, 1 = cra

--- a/src/BlackSP.Benchmarks/Properties/launchSettings.json
+++ b/src/BlackSP.Benchmarks/Properties/launchSettings.json
@@ -61,8 +61,6 @@
     "Collect latency metrics": {
       "commandName": "Project",
       "environmentVariables": {
-        "AZURE_STORAGE_CONN_STRING": "DefaultEndpointsProtocol=https;AccountName=vertexstore;AccountKey=3BMGVlrXZq8+NE9caC47KDcpZ8X59vvxFw21NLNNLFhKGgmA8Iq+nr7naEd7YuGGz+M0Xm7dSUhgkUN5N9aMLw==;EndpointSuffix=core.windows.net",
-
         "KAFKA_BROKER_DNS_TEMPLATE": "localhost:3240{0}", //kafka-{0}.kafka.kafka.svc.cluster.local:9092
         "KAFKA_BROKER_COUNT": "1",
         "KAFKA_TOPIC_PARTITION_COUNT": "24",
@@ -76,8 +74,6 @@
     "Collect throughput metrics": {
       "commandName": "Project",
       "environmentVariables": {
-        "AZURE_STORAGE_CONN_STRING": "DefaultEndpointsProtocol=https;AccountName=vertexstore;AccountKey=3BMGVlrXZq8+NE9caC47KDcpZ8X59vvxFw21NLNNLFhKGgmA8Iq+nr7naEd7YuGGz+M0Xm7dSUhgkUN5N9aMLw==;EndpointSuffix=core.windows.net",
-
         "KAFKA_BROKER_DNS_TEMPLATE": "localhost:3240{0}", //kafka-{0}.kafka.kafka.svc.cluster.local:9092
         "KAFKA_BROKER_COUNT": "1",
         "KAFKA_TOPIC_PARTITION_COUNT": "24",
@@ -88,24 +84,21 @@
       "commandLineArgs": "throughput"
     },
 
-    "Run benchmark on BlackSP": {
+    "Run in simulator": {
       "commandName": "Project",
       "environmentVariables": {
-        "AZURE_STORAGE_CONN_STRING": "DefaultEndpointsProtocol=https;AccountName=vertexstore;AccountKey=3BMGVlrXZq8+NE9caC47KDcpZ8X59vvxFw21NLNNLFhKGgmA8Iq+nr7naEd7YuGGz+M0Xm7dSUhgkUN5N9aMLw==;EndpointSuffix=core.windows.net",
-        "AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=vertexstore;AccountKey=3BMGVlrXZq8+NE9caC47KDcpZ8X59vvxFw21NLNNLFhKGgmA8Iq+nr7naEd7YuGGz+M0Xm7dSUhgkUN5N9aMLw==;EndpointSuffix=core.windows.net",
-
         "KAFKA_BROKER_DNS_TEMPLATE": "localhost:3240{0}", //"kafka-{0}.kafka.kafka.svc.cluster.local:9092"
         "KAFKA_BROKER_COUNT": "1",
         "KAFKA_TOPIC_PARTITION_COUNT": "24",
 
         "LOG_TARGET_FLAGS": "3", // 1 (console) || 2 (file) || 4 (azure blob)
-        "LOG_EVENT_LEVEL": "1", //0-5,
+        "LOG_EVENT_LEVEL": "2", //0-5,
 
         "CHECKPOINT_COORDINATION_MODE": "2", //0 = uc, 1 = cc, 2 = cic
         "CHECKPOINT_INTERVAL_SECONDS": "15",
 
         "BENCHMARK_INFRA": "0", //0 = simulator, 1 = cra
-        "BENCHMARK_JOB": "6", //0-6
+        "BENCHMARK_JOB": "-1", //-1 - 6
         "BENCHMARK_SIZE": "0", // 0 = S, 1 = M, 2 = L
 
         "CRA_WORKER_DOCKER_IMAGE": "mdzwart/cra-net3.1:latest",
@@ -117,9 +110,6 @@
     "Run local worker": {
       "commandName": "Project",
       "environmentVariables": {
-        "AZURE_STORAGE_CONN_STRING": "DefaultEndpointsProtocol=https;AccountName=vertexstore;AccountKey=3BMGVlrXZq8+NE9caC47KDcpZ8X59vvxFw21NLNNLFhKGgmA8Iq+nr7naEd7YuGGz+M0Xm7dSUhgkUN5N9aMLw==;EndpointSuffix=core.windows.net",
-        "AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=https;AccountName=vertexstore;AccountKey=3BMGVlrXZq8+NE9caC47KDcpZ8X59vvxFw21NLNNLFhKGgmA8Iq+nr7naEd7YuGGz+M0Xm7dSUhgkUN5N9aMLw==;EndpointSuffix=core.windows.net",
-
         "KAFKA_BROKER_DNS_TEMPLATE": "localhost:3240{0}", //"kafka-{0}.kafka.kafka.svc.cluster.local:9092"
         "KAFKA_BROKER_COUNT": "1",
         "KAFKA_TOPIC_PARTITION_COUNT": "24",

--- a/src/BlackSP.Benchmarks/WordCount/Operators/KafkaWordCountSink.cs
+++ b/src/BlackSP.Benchmarks/WordCount/Operators/KafkaWordCountSink.cs
@@ -40,18 +40,18 @@ namespace BlackSP.Benchmarks.WordCount.Operators
 
         public Task Sink(WordEvent @event)
         {
-            if(_wordCountMap.ContainsKey(@event.Word))
+            if (_wordCountMap.ContainsKey(@event.Word))
             {
                 _wordCountMap[@event.Word] += @event.Count;
-            } 
+            }
             else
             {
                 _wordCountMap.Add(@event.Word, @event.Count);
             }
             //var wordCountStrings = _wordCountMap.OrderBy(p => p.Key).Select(x => x.Key + "=" + x.Value).ToArray();
             //_logger.Debug($"WordCount: {string.Join("; ", wordCountStrings)}");
-            
-            var outputValue = @event.EventTime.ToString("yyyyMMddHHmmssFFFFF")+"$"+DateTime.UtcNow.ToString("yyyyMMddHHmmssFFFFF")+"$"+@event.EventCount();
+
+            var outputValue = @event.EventTime.ToString("yyyyMMddHHmmssFFFFF") + "$" + DateTime.UtcNow.ToString("yyyyMMddHHmmssFFFFF") + "$" + @event.EventCount();
             producer.Produce("output", new Message<int, string> { Key = @event.Key ?? default, Value = outputValue });
             return Task.CompletedTask;
             //producer.Flush();
@@ -72,13 +72,6 @@ namespace BlackSP.Benchmarks.WordCount.Operators
                 disposedValue = true;
             }
         }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~WordCountLoggerSink()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
 
         public void Dispose()
         {

--- a/src/BlackSP.Benchmarks/WordCount/Operators/TestSentenceGeneratorSource.cs
+++ b/src/BlackSP.Benchmarks/WordCount/Operators/TestSentenceGeneratorSource.cs
@@ -11,9 +11,9 @@ using BlackSP.Kernel.Configuration;
 
 namespace BlackSP.Benchmarks.WordCount.Operators
 {
-    class TestSentenceGeneratorSource : Kafka.KafkaSourceConsumerBase<string>, ISourceOperator<SentenceEvent>
+    class TestSentenceGeneratorSource : ISourceOperator<SentenceEvent>
     {
-        private static string[] defaultSentences = new[] { "asdlkfnmjalksjnhfdlkashbfkjasdbhf", "asldkfjnmalskfnhjlakshdfbnkjashdf asdflkmjnaskldfjlkashdfasdf", "asdflkmjaslkfdjasklhdjfasdf asdflknaskldfjnalskdhjfnasdfasdfasf askldjfnaslkjdfhnaslkhjdfasdfasdf", "asdflkmnjcasklhjfdnasdf askldfjmhalkjhcnrasdf lkjfdmlakjsdflaksjhnfdlkasd lsdjkmgfkasjhdfnakjha" };//new[] { "A", "A B", "A B C", "A B C D" };
+        private static string[] defaultSentences = new[] { "A", "A B", "A B C", "A B C D" };
 
         [ApplicationState]
         private int lastSentenceIndex;
@@ -23,11 +23,9 @@ namespace BlackSP.Benchmarks.WordCount.Operators
         
         private readonly ILogger _logger;
 
-        private int MaxSentenceCount => int.MaxValue;// defaultSentences.Length * 50000;
+        private int MaxSentenceCount => defaultSentences.Length * 50000;
 
-        protected override string TopicName => "sentences";
-
-        public TestSentenceGeneratorSource(IVertexConfiguration config, ILogger logger) : base(config, logger)
+        public TestSentenceGeneratorSource(ILogger logger)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             lastSentenceIndex = 0;
@@ -53,12 +51,6 @@ namespace BlackSP.Benchmarks.WordCount.Operators
             lastSentenceIndex = (lastSentenceIndex + 1) % defaultSentences.Length; //round robin pick sentences
             sentencesGenerated++;
             //_logger.Debug($"Sending {defaultSentences[i]} ({i} , {lastSentenceIndex})");
-            //var x = Consumer.Consume(t);
-            //var huh = x.Message.Value;
-            //if (huh == "lol")
-            //{
-            //    sentencesGenerated++;
-            //}
             return new SentenceEvent
             {
                 Sentence = defaultSentences[i],

--- a/src/BlackSP.Benchmarks/WordCount/Operators/TestWordCountSink.cs
+++ b/src/BlackSP.Benchmarks/WordCount/Operators/TestWordCountSink.cs
@@ -1,0 +1,46 @@
+﻿using BlackSP.Checkpointing;
+using BlackSP.Kernel.Operators;
+using BlackSP.Benchmarks.WordCount.Events;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using BlackSP.Benchmarks.Kafka;
+
+namespace BlackSP.Benchmarks.WordCount.Operators
+{
+    class TestWordCountSink : ISinkOperator<WordEvent>
+    {
+
+        private readonly ILogger _logger;
+
+        [ApplicationState]
+        private IDictionary<string, int> _wordCountMap;
+
+        public TestWordCountSink(ILogger logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _wordCountMap = new Dictionary<string, int>();
+        }
+
+        public Task Sink(WordEvent @event)
+        {
+            if (_wordCountMap.ContainsKey(@event.Word))
+            {
+                _wordCountMap[@event.Word] += @event.Count;
+            }
+            else
+            {
+                _wordCountMap.Add(@event.Word, @event.Count);
+            }
+            var wordCountStrings = _wordCountMap.OrderBy(p => p.Key).Select(x => x.Key + "=" + x.Value).ToArray();
+            _logger.Information($"WordCount: {string.Join("; ", wordCountStrings)}");
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
removes secrets from the repository - you can add them to your development environment by using Visual Studios "Manage User Secrets" functionality (right click the Benchmarks project). Add the two connection string keys with a connection string to your own Azure Storage.

Also provides a 'new query' which runs wordcount without kafka so its easier to spin up. Should run straight away in the simulator, also eases running in kubernetes since it does not require you to spin up your own kafka brokers. 

@jorgeSia I appear unable to tag Gianni, is he not added to delfdata or am i goofing?